### PR TITLE
Updated string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="reservationCancelInfo">You can cancel reservations that were originally made from a room tablet</string>
     <string name="touchToReserve">Tap to see schedule</string>
     <string name="bookNow">Use room now</string>
-    <string name="disconnectedWarning">Disconnected!</string>
+    <string name="disconnectedWarning">Ei yhteyttä | osammanhängande | disconnected</string>
     <string name="aboutInfo">Reservator is made by Futurice, a lean service creation company with offices in Helsinki, Tampere, Berlin, Munich, Stockholm and London. More information at: www.futurice.com.\n\nThis application is published under the BSD license. You can find the source code at: http://github.com/futurice/meeting-room-tablet</string>
     <string name="aboutTitle">About</string>
     <string name="addressBookOptionLabel">Require address book contacts for reserving</string>


### PR DESCRIPTION
Addresses issue #76, but what may be better is to just pick a default (Finnish probably) for the trilingual version, then just have a version per language, if the non-trilingual version is selected during startup.