### PR TITLE
Fixed bugs in day calendar. Fix issue #94

### DIFF
--- a/app/src/main/java/com/futurice/android/reservator/view/WeekView.java
+++ b/app/src/main/java/com/futurice/android/reservator/view/WeekView.java
@@ -109,7 +109,7 @@ public class WeekView extends RelativeLayout implements OnClickListener {
                 day.getStart().add(Calendar.DAY_OF_YEAR, 1),
                 day.getEnd().add(Calendar.DAY_OF_YEAR, 1));
         }
-
+        cv.setRoom(room);
         cv.setReservations(reservations);
         calendarFrame.addView(cv, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
         cv.setOnClickListener(this);

--- a/app/src/main/java/com/futurice/android/reservator/view/trafficlights/RoomReservationFragment.java
+++ b/app/src/main/java/com/futurice/android/reservator/view/trafficlights/RoomReservationFragment.java
@@ -22,6 +22,8 @@ public class RoomReservationFragment extends Fragment {
         void setRoomReservationFragment(RoomReservationFragment fragment);
         void onReservationRequestMade(int minutes, String description);
         void onMinutesUpdated(int minutes);
+        void onTentativeChangeStarted();
+        void onTentativeChangeEnded();
     }
 
     private RoomReservationPresenter presenter;
@@ -92,6 +94,9 @@ public class RoomReservationFragment extends Fragment {
             this.nameInput.setText("");
     }
 
+    public int getCurrentMinutes() {
+        return seekBar.getProgress();
+    }
 
     SeekBar.OnSeekBarChangeListener seekBarChangeListener = new SeekBar.OnSeekBarChangeListener() {
         int minutesIncrement = 5;
@@ -117,11 +122,13 @@ public class RoomReservationFragment extends Fragment {
 
         @Override
         public void onStartTrackingTouch(android.widget.SeekBar seekBar) {
+            //savedProgress = ((int) Math.round(seekBar.getProgress() / minutesIncrement)) * minutesIncrement;
+            presenter.onTentativeChangeStarted();
         }
 
         @Override
         public void onStopTrackingTouch(android.widget.SeekBar seekBar) {
-
+            presenter.onTentativeChangeEnded();
         }
     };
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,8 +20,8 @@
     <color name="StatusFreeColor">#0098d0</color>
     <color name="StatusReservedColor">#CCe5053a</color> //red
     <color name="Transparent">#0000</color>
-    <color name="CalendarMarkerReservedColor">#CCe5053a</color>
-    <color name="CalendarMarkerTentativeColor">#80e5053a</color>
+    <color name="CalendarMarkerReservedColor">#e5053a</color>
+    <color name="CalendarMarkerTentativeColor">#30e5053a</color>
     <color name="Orange">#fca311</color>
     <color name="TimeBarTickColor">#3333</color>
     <color name="ButtonTextNormal">#333</color>


### PR DESCRIPTION
Fixed a lot of buggy-looking behavior in day calendar:

- Moved reservation names up
- Only show reservation names in reservations that are long enough for showing the text
- Made the red of the reservations solid red with no transparency
- Added more transparency to the tentative reservation color
- Made the tentative reservation area move correctly as time goes on
